### PR TITLE
Use different image and pre-test job for analytics plugin

### DIFF
--- a/build.gocd.groovy
+++ b/build.gocd.groovy
@@ -1,62 +1,20 @@
 import cd.go.contrib.plugins.configrepo.groovy.dsl.GoCD
 import cd.go.contrib.plugins.configrepo.groovy.dsl.Job
 
-def allRepos = [
-  "gocd-contrib": [
-    "gocd-guest-login-plugin",
-    "email-notifier",
-    "google-oauth-authorization-plugin",
-    "gitlab-oauth-authorization-plugin",
-    "github-oauth-authorization-plugin",
-    "gocd-groovy-dsl-config-plugin",
-    "docker-elastic-agents-plugin",
-    "docker-swarm-elastic-agent-plugin",
-    "gitter-notifier",
-    "gitter-activity-feed-plugin",
-    "gocd-build-status-notifier",
-    "go-nuget-poller-plugin-2.0"
-  ],
-  "gocd"        : [
-    "gocd-file-based-secrets-plugin",
-    "gocd-filebased-authentication-plugin",
-    "kubernetes-elastic-agents",
-    "docker-registry-artifact-plugin",
-    "gocd-ldap-authentication-plugin",
-    "gocd-yum-repository-poller-plugin",
-    "gocd-kubernetes-based-secrets-plugin",
-    "gocd-vault-secret-plugin",
-    "gocd-aws-based-secrets-plugin",
-    "azure-elastic-agent-plugin",
-    "gocd-ecs-elastic-agent",
-    "gocd-ldap-authorization-plugin",
-    "gocd-analytics-plugin"
-  ]
-]
-
-def releaseCredentials = {
-  return [
-    GITHUB_TOKEN: 'AES:9Z9Lv85kry1oWWlOaCUF/w==:fWti8kD99VN7f++r7PfgLmXulS8GPmyb8bWm7yl1DYoDh1QihWEumO1mCfwiJ/O0',
-  ]
-}
-
-def getElasticProfile = { repo ->
-  "ecs-gocd-dev-build-dind"
-}
-
 def javaTestJobs = { repo ->
   return [
-    new Job("test", {
-      elasticProfileId = getElasticProfile(repo)
-      tasks {
-        exec { commandLine = ['./gradlew', 'assemble', 'check'] }
-      }
-    })
+          new Job("test", {
+            elasticProfileId = repo['elasticProfileForTests']
+            tasks {
+              exec { commandLine = ['./gradlew', 'assemble', 'check'] }
+            }
+          })
   ]
 }
 
-def docker_versions = ["17.03.2-ce", "17.06.2-ce", "17.09.1-ce", "17.12.1-ce", "18.03.1-ce", "18.06.3-ce", "18.09.6"]
+def dockerTestJobs = { repo ->
+  def docker_versions = ["17.03.2-ce", "17.06.2-ce", "17.09.1-ce", "17.12.1-ce", "18.03.1-ce", "18.06.3-ce", "18.09.6"]
 
-def dockerTestJobs = {
   return docker_versions.collect { version ->
     new Job("test-$version", {
       elasticProfileId = "ecs-dind-gocd-agent"
@@ -69,77 +27,98 @@ def dockerTestJobs = {
   }
 }
 
-def testJobs = { repo ->
-  return [
-    "docker-elastic-agents-plugin",
-    "docker-swarm-elastic-agent-plugin"
-  ].contains(repo) ? dockerTestJobs() : javaTestJobs(repo)
-}
+def defaultElasticProfile = 'ecs-gocd-dev-build-dind'
 
-def repoBranch = {repo ->
+def allRepos = [
+    [ 'org': 'gocd-contrib', repo: 'gocd-guest-login-plugin',              elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'email-notifier',                       elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'google-oauth-authorization-plugin',    elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'gitlab-oauth-authorization-plugin',    elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'github-oauth-authorization-plugin',    elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'gocd-groovy-dsl-config-plugin',        elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'docker-elastic-agents-plugin',         elasticProfileForTests: 'ecs-dind-gocd-agent',       testJobs: dockerTestJobs, mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'docker-swarm-elastic-agent-plugin',    elasticProfileForTests: 'ecs-dind-gocd-agent',       testJobs: dockerTestJobs, mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'gitter-notifier',                      elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'gitter-activity-feed-plugin',          elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'gocd-build-status-notifier',           elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd-contrib', repo: 'go-nuget-poller-plugin-2.0',           elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-file-based-secrets-plugin',       elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-filebased-authentication-plugin', elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'kubernetes-elastic-agents',            elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'docker-registry-artifact-plugin',      elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-ldap-authentication-plugin',      elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-yum-repository-poller-plugin',    elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-kubernetes-based-secrets-plugin', elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-vault-secret-plugin',             elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-aws-based-secrets-plugin',        elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'azure-elastic-agent-plugin',           elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-ecs-elastic-agent',               elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-ldap-authorization-plugin',       elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
+    [ 'org': 'gocd',         repo: 'gocd-analytics-plugin',                elasticProfileForTests: 'ecs-gocd-dev-build-dind', testJobs: javaTestJobs,   mainBranch: 'main'   ],
+  ]
+
+def releaseCredentials = {
   return [
-    "gocd-analytics-plugin",
-  ].contains(repo) ? "main" : "master"
+    GITHUB_TOKEN: 'AES:9Z9Lv85kry1oWWlOaCUF/w==:fWti8kD99VN7f++r7PfgLmXulS8GPmyb8bWm7yl1DYoDh1QihWEumO1mCfwiJ/O0',
+  ]
 }
 
 GoCD.script {
   pipelines {
-    allRepos.each { org, repos ->
-      repos.each { repo ->
-        pipeline("${org}-${repo}-pr") {
-          materials {
-            githubPR("$repo-material") {
-              url = "https://git.gocd.io/git/$org/$repo"
-            }
+    allRepos.each { repo ->
+      pipeline("${repo['org']}-${repo['repo']}-pr") {
+        materials {
+          githubPR("${repo['repo']}-material") {
+            url = "https://git.gocd.io/git/${repo['org']}/${repo['repo']}"
           }
-          group = "gocd" == org ? "supported-plugins-pr" : "plugins-pr"
-          stages {
-            stage("test") {
-              jobs {
-                addAll(testJobs(repo))
-              }
+        }
+        group = "gocd" == repo['org'] ? "supported-plugins-pr" : "plugins-pr"
+        stages {
+          stage("test") {
+            jobs {
+              addAll(repo['testJobs'](repo))
             }
           }
         }
-        pipeline("${org}-${repo}") {
-          materials {
-            git {
-              url = "https://git.gocd.io/git/${org}/${repo}"
-              shallowClone = false
-              branch = repoBranch(repo)
+      }
+      pipeline("${repo['org']}-${repo['repo']}") {
+        materials {
+          git {
+            url = "https://git.gocd.io/git/${repo['org']}/${repo['repo']}"
+            shallowClone = false
+            branch = repo['mainBranch']
+          }
+        }
+        group = "gocd" == repo['org'] ? "supported-plugins" : "plugins"
+        stages {
+          stage("test") {
+            jobs {
+              addAll(repo['testJobs'](repo))
             }
           }
-          group = "gocd" == org ? "supported-plugins" : "plugins"
-          stages {
-            stage("test") {
-              jobs {
-                addAll(testJobs(repo))
-              }
-            }
 
-            stage("github-preview-release") {
-              environmentVariables = [GITHUB_USER: org]
-              secureEnvironmentVariables = releaseCredentials()
-              jobs {
-                job("create-preview-release") {
-                  elasticProfileId = getElasticProfile(repo)
-                  tasks {
-                    exec { commandLine = ['./gradlew', 'githubRelease'] }
-                  }
+          stage("github-preview-release") {
+            environmentVariables = [GITHUB_USER: repo['org']]
+            secureEnvironmentVariables = releaseCredentials()
+            jobs {
+              job("create-preview-release") {
+                elasticProfileId = defaultElasticProfile
+                tasks {
+                  exec { commandLine = ['./gradlew', 'githubRelease'] }
                 }
               }
             }
+          }
 
-            stage("github-release") {
-              approval { type = 'manual' }
-              environmentVariables = [GITHUB_USER: org, PRERELEASE: "NO"]
-              secureEnvironmentVariables = releaseCredentials()
-              jobs {
-                job("create-release") {
-                  elasticProfileId = getElasticProfile(repo)
-                  tasks {
-                    exec { commandLine = ['./gradlew', 'githubRelease'] }
-                  }
+          stage("github-release") {
+            approval { type = 'manual' }
+            environmentVariables = [GITHUB_USER: repo['org'], PRERELEASE: "NO"]
+            secureEnvironmentVariables = releaseCredentials()
+            jobs {
+              job("create-release") {
+                elasticProfileId = defaultElasticProfile
+                tasks {
+                  exec { commandLine = ['./gradlew', 'githubRelease'] }
                 }
               }
             }

--- a/build.gocd.groovy
+++ b/build.gocd.groovy
@@ -54,7 +54,7 @@ def allRepos = [
     [ 'org': 'gocd',         repo: 'azure-elastic-agent-plugin',           elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
     [ 'org': 'gocd',         repo: 'gocd-ecs-elastic-agent',               elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
     [ 'org': 'gocd',         repo: 'gocd-ldap-authorization-plugin',       elasticProfileForTests: 'ecs-gocd-dev-build-dind',   testJobs: javaTestJobs,   mainBranch: 'master' ],
-    [ 'org': 'gocd',         repo: 'gocd-analytics-plugin',                elasticProfileForTests: 'ecs-gocd-dev-build-dind', testJobs: javaTestJobs,   mainBranch: 'main'   ],
+    [ 'org': 'gocd',         repo: 'gocd-analytics-plugin',                elasticProfileForTests: 'ecs-plugin-build-postgres', testJobs: javaTestJobs,   mainBranch: 'main'   ],
   ]
 
 def releaseCredentials = {


### PR DESCRIPTION
Analytics plugin needs a different elastic agent profile and a special job to run before tests run (to bring up Postgres).

##### The earliest commit with the subject "Refactor allRepos"

Pushes more data into allRepos, so that it can be controlled per repo. The output JSON before and after this change is the same. It can be verified using:

```bash
java -jar gocd-groovy-dsl-config-plugin-1.0.3-167.jar syntax -j build.gocd.groovy 2>&1 | sed -n '/Showing JSON from file/,$p' | tail -n +3
```

If that is run before and after the commit, the output will be the same when compared with:

```bash
diff <(jq . <orig.json) <(jq . <new.json)
```

